### PR TITLE
fix handling for users without password

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,20 +5,20 @@ $(info $(shell mkdir -p $(DIST_DIR)))
 
 default: all
 
-all: lint modupdate build test run docs clean
+all: lint modupdate build test docs clean
 
 build:
 	go build -o "${DIST_DIR}/${BINARY_NAME}" main.go
 
 lint:
-	~/go/bin/tfproviderlintx -R001=false ./...
+	tfproviderlint -R001=false ./...
 
 modupdate:
 	go get -u
 	go mod tidy
 
 docs:
-	~/go/bin/tfplugindocs generate
+	tfplugindocs generate
 
 test: build
 	./scripts/test.sh

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -46,7 +46,7 @@ terraform import lldap_user.example admin
 - `display_name` (String) Display name of this user
 - `first_name` (String) First name of this user
 - `last_name` (String) Last name of this user
-- `password` (String, Sensitive) Password for the user
+- `password` (String, Sensitive) Password for the user. Note that the provider cannot read the password from LLDAP, so if this value is not set, the password attribute will be entirely ignored by the provider
 
 ### Read-Only
 

--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	golang.org/x/tools v0.32.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250414145226-207652e42e2e // indirect
-	google.golang.org/grpc v1.71.1 // indirect
+	google.golang.org/grpc v1.72.0 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -187,8 +187,8 @@ google.golang.org/appengine v1.6.8 h1:IhEN5q69dyKagZPYMSdIjS2HqprW324FRQZJcGqPAs
 google.golang.org/appengine v1.6.8/go.mod h1:1jJ3jBArFh5pcgW8gCtRJnepW8FzD1V44FJffLiz/Ds=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20250414145226-207652e42e2e h1:ztQaXfzEXTmCBvbtWYRhJxW+0iJcz2qXfd38/e9l7bA=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20250414145226-207652e42e2e/go.mod h1:qQ0YXyHHx3XkvlzUtpXDkS29lDSafHMZBAZDc03LQ3A=
-google.golang.org/grpc v1.71.1 h1:ffsFWr7ygTUscGPI0KKK6TLrGz0476KUvvsbqWK0rPI=
-google.golang.org/grpc v1.71.1/go.mod h1:H0GRtasmQOh9LkFoCPDu3ZrwUtD1YGE+b2vYBYd/8Ec=
+google.golang.org/grpc v1.72.0 h1:S7UkcVa60b5AAQTaO6ZKamFp1zMZSU0fGDK2WZLbBnM=
+google.golang.org/grpc v1.72.0/go.mod h1:wH5Aktxcg25y1I3w7H69nHfXdOG3UiadoBtjh3izSDM=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.36.6 h1:z1NpPI8ku2WgiWnf+t9wTPsn6eP1L7ksHUlkfLvd9xY=

--- a/tests/user-change/tofu.sh
+++ b/tests/user-change/tofu.sh
@@ -18,3 +18,15 @@ tofu apply -auto-approve
 tofu taint random_string.email_prefix
 tofu apply -auto-approve
 tofu apply -auto-approve -destroy
+
+# Ensure an user initially created without password can set one later
+tofu apply -auto-approve
+tofu apply -auto-approve -var nopasswd="yespasswd"
+tofu plan -detailed-exitcode -var nopasswd="yespasswd"
+tofu apply -auto-approve -destroy
+
+# Ensure an user initially created with password can remove it later
+tofu apply -auto-approve -var nopasswd="yespasswd"
+tofu apply -auto-approve
+tofu plan -detailed-exitcode
+tofu apply -auto-approve -destroy

--- a/tests/user-change/user-change.tf
+++ b/tests/user-change/user-change.tf
@@ -38,9 +38,20 @@ resource "random_string" "email_prefix" {
 
 resource "lldap_user" "user" {
   username     = "user"
-  email        = "${random_string.email_prefix.result}@this.test"
+  email        = "user-${random_string.email_prefix.result}@this.test"
   password     = random_password.user.result
   display_name = "User"
   first_name   = "FIRST"
   last_name    = "LAST"
+}
+
+variable "nopasswd" {
+  type    = string
+  default = null
+}
+
+resource "lldap_user" "nopasswd" {
+  username     = "user-nopasswd-change"
+  email        = "nopasswd-${random_string.email_prefix.result}@this.test"
+  password     = var.nopasswd
 }

--- a/tests/user/nopasswd.tf
+++ b/tests/user/nopasswd.tf
@@ -1,0 +1,9 @@
+resource "lldap_user" "nopasswd" {
+  username     = "user-nopasswd"
+  email        = "user-nopasswd@this.test"
+}
+
+output "nopasswd" {
+  value     = lldap_user.nopasswd
+  sensitive = true
+}

--- a/tests/user/user.tftest.hcl
+++ b/tests/user/user.tftest.hcl
@@ -48,7 +48,7 @@ run "test_user" {
 run "test_users_map" {
   // Map is a data source so we need to retest the values from the resource
   assert {
-    condition     = length(keys(output.users_map)) == 1 + local.user_count // default "admin" plus our new users
+    condition     = length(keys(output.users_map)) == 1 + local.user_count + 1 // default "admin" plus our count new users plus newpasswd user
     error_message = "could not find users"
   }
   assert {
@@ -90,5 +90,12 @@ run "test_users_map" {
   assert {
     condition     = output.users_map["user1"].avatar == output.avatar_base64
     error_message = "Invalid value for user avatar base64"
+  }
+}
+
+run "test_nopasswd_user" {
+  assert {
+    condition     = output.nopasswd.password == null
+    error_message = "invalid value for no password"
   }
 }


### PR DESCRIPTION
The provider attempted to set a password even if none was given and failed since LLDAP does not accept empty passwords. With this fix will the provider ignore the user password entirely if it is not set in the resource: Since we cannot check the password in LLDAP, we cannot even check whether it has changed if none is given, so management is not possible.

This also updates the go dependencies and fixes hardcoded paths in the Makefile.

See also: https://github.com/tasansga/terraform-provider-lldap/issues/16 and possibly https://github.com/tasansga/terraform-provider-lldap/issues/13